### PR TITLE
Improve wandb logging

### DIFF
--- a/magi/agents/sac/learning.py
+++ b/magi/agents/sac/learning.py
@@ -175,7 +175,7 @@ class SACLearner(core.Learner, core.VariableSource):
             self._alpha_opt_state,
             entropy=actor_stats["entropy"],
         )
-        self._counter.increment(steps=1)
+        counts = self._counter.increment(steps=1)
         results = {
             "q1": critic_stats["q1"],
             "q2": critic_stats["q2"],
@@ -184,6 +184,7 @@ class SACLearner(core.Learner, core.VariableSource):
             "alpha_loss": loss_alpha,
             "actor_loss": loss_actor,
             "entropy": actor_stats["entropy"],
+            **counts,
         }
         self._logger.write(results)
         # Update target network.

--- a/magi/examples/pets/run_mujoco.py
+++ b/magi/examples/pets/run_mujoco.py
@@ -59,15 +59,15 @@ def main(unused_argv):
     del unused_argv
     np.random.seed(FLAGS.seed)
     rng = np.random.default_rng(FLAGS.seed + 1)
-    if FLAGS.wandb:
-        import wandb  # pylint: disable=import-outside-toplevel
+    # if FLAGS.wandb:
+    #     import wandb  # pylint: disable=import-outside-toplevel
 
-        wandb.init(
-            project=FLAGS.wandb_project,
-            entity=FLAGS.wandb_entity,
-            name=f"pets-{FLAGS.env}_{FLAGS.seed}_{int(time.time())}",
-            config=FLAGS,
-        )
+    #     wandb.init(
+    #         project=FLAGS.wandb_project,
+    #         entity=FLAGS.wandb_entity,
+    #         name=f"pets-{FLAGS.env}_{FLAGS.seed}_{int(time.time())}",
+    #         config=FLAGS,
+    #     )
     environment, config = make_environment(FLAGS.env, int(rng.integers(0, 2 ** 32)))
     environment_spec = specs.make_environment_spec(environment)
     print("observation spec", environment_spec.observations.shape)
@@ -97,7 +97,16 @@ def main(unused_argv):
         patience=config.patience,
     )
 
-    logger = loggers.make_logger("environment_loop", use_wandb=FLAGS.wandb)
+    logger = loggers.make_logger(
+        "environment_loop",
+        use_wandb=FLAGS.wandb,
+        wandb_kwargs={
+            "project": FLAGS.wandb_project,
+            "entity": FLAGS.wandb_entity,
+            "name": f"pets-{FLAGS.env}_{FLAGS.seed}_{int(time.time())}",
+            "config": FLAGS,
+        },
+    )
     total_num_steps = 0
     for episode in range(FLAGS.num_episodes):
         timestep = environment.reset()
@@ -124,6 +133,8 @@ def main(unused_argv):
         )
 
     if FLAGS.wandb:
+        import wandb
+
         wandb.finish()
 
 


### PR DESCRIPTION
Closes #29 
1. Add steps_key option to configure counter for logger.
2. Initialize wandb in first wandb logger creation.
3. Update SAC and PETS examples to use the new logger config.