### PR TITLE
Fix installing dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   rev: 21.6b0
   hooks:
   - id: black
-    language_version: python3.7
+    language_version: python3
 
 - repo: https://gitlab.com/pycqa/flake8.git
   rev: 3.9.2

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 SRC = magi
+N_CPUS ?= $(shell grep -c ^processor /proc/cpuinfo)
 
 .PHONY: typecheck
 typecheck:
-	pytype $(shell grep -c ^processor /proc/cpuinfo) $(SRC)
+	pytype -j $(N_CPUS) $(SRC)
 
 .PHONY: test
 test:
-	pytest --color=yes -rf --ignore=magi/agents/archived --ignore=magi/experimental \
-	 $(SRC)
+	JAX_PLATFORM_NAME=cpu pytest -n $(N_CPUS) \
+		--color=yes \
+		-rf \
+		--ignore=magi/agents/archived \
+		--ignore=magi/experimental \
+		$(SRC)
 
 .PHONY: isort
 isort:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 **[Examples](./magi/examples)** |
 **[Contributing](./CONTRIBUTING.md)** |
 **[Documentation](./docs)**
-<!-- **[Examples]** -->
 
 [![pytest](https://github.com/ethanluoyc/magi/actions/workflows/ci.yaml/badge.svg?branch=develop)](https://github.com/ethanluoyc/magi/actions/workflows/ci.yaml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
@@ -23,8 +22,19 @@ python3 -m venv venv
 2. Install dependencies and the package in editable mode by running
 
 ```python
-pip install -f https://storage.googleapis.com/jax-releases/jax_releases.html -e .
+pip install jax==0.2.11 jaxlib==0.1.64
 pip install -e '.[dev,envs]'
+```
+
+Magi is tested against jax==0.2.11 and jaxlib==0.1.64 but it should also work
+with more recent versions of jax and jaxlib.
+Note that the installation above uses the CPU verison of JAX.
+If you want to use JAX with the CUDA backend, follow the instructions
+on JAX's GitHub repo for how to install the CUDA-enabled version of jaxlib.
+For CUDA 11.3, you can replace the commands above with
+
+```bash
+pip install jax==0.2.11 jaxlib==0.1.64+cuda111 -f https://storage.googleapis.com/jax-releases/jax_releases.html # will use the jaxlib version with CUDA 11.3 support
 ```
 
 If for some reason installation fails, first check out GitHub Actions
@@ -44,11 +54,11 @@ we include examples of using our RL agents on popular benchmark tasks.
 ## Testing
 On Linux, you can run tests with
 ```
-pytest -n `grep -c ^processor /proc/cpuinfo` magi
+JAX_PLATFORM_NAME=cpu pytest -n `grep -c ^processor /proc/cpuinfo` magi
 ```
 
 ## Contributing
-Refer to [CONTRIBUTING.md](./CONTRIBUTING.md)
+Refer to [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Acknowledgements
 Magi is inspired by many of the open-source RL projects out there. Since we

--- a/magi/agents/README.md
+++ b/magi/agents/README.md
@@ -12,7 +12,7 @@ For the JAX agents, we use
 1. [dm-haiku](https://github.com/deepmind/dm-haiku) for implementing the neural network modules,
 2, [optax](https://github.com/deepmind/optax) for building optimizers,
 3. [rlax](https://github.com/deepmind/rlax/tree/master/rlax) for RL loss functions,
-4. TensorFlow Probability's (TFP) JAX [substrates](https://www.tensorflow.org/probability/api_docs/python/tfp/substrates/jax) and [Distrax](https://github.com/deepmind/distrax) to build
+4. TensorFlow Probability's (TFP) JAX [substrates](https://www.tensorflow.org/probability/api_docs/python/tfp/substrates/jax) to build
 probability distributions primitives,
 5. [dm-reverb](https://github.com/deepmind/reverb) for scalable replay buffer implementation.
 

--- a/magi/agents/drq/agent_test.py
+++ b/magi/agents/drq/agent_test.py
@@ -14,11 +14,18 @@ class SACTest(absltest.TestCase):
     def test_sac_ae(self):
         # Create a fake environment to test with.
         environment = fakes.ContinuousVisualEnvironment(
-            action_dim=2, observation_shape=(84, 84, 3), episode_length=10, bounded=True
+            action_dim=2, observation_shape=(32, 32, 3), episode_length=10, bounded=True
         )
         spec = specs.make_environment_spec(environment)
         # Construct the agent.
-        network_spec = networks.make_default_networks(spec)
+        network_spec = networks.make_default_networks(
+            spec,
+            critic_hidden_sizes=(10, 10),
+            actor_hidden_sizes=(10, 10),
+            latent_size=10,
+            num_layers=1,
+            num_filters=2,
+        )
         agent = DrQAgent(
             environment_spec=spec,
             networks=network_spec,

--- a/magi/agents/sac/agent_test.py
+++ b/magi/agents/sac/agent_test.py
@@ -12,14 +12,16 @@ from magi.agents.sac.agent import SACAgent
 
 def policy_fn(action_spec):
     def fn(x):
-        return networks.GaussianPolicy(action_size=action_spec.shape[0])(x)
+        return networks.GaussianPolicy(
+            hidden_units=(32, 32), action_size=action_spec.shape[0]
+        )(x)
 
     return fn
 
 
 def critic_fn():
     def fn(x, a):
-        critic = networks.DoubleCritic()
+        critic = networks.DoubleCritic(hidden_units=(32, 32))
         return critic(x, a)
 
     return fn

--- a/magi/agents/sac_ae/agent_test.py
+++ b/magi/agents/sac_ae/agent_test.py
@@ -18,7 +18,12 @@ class SACTest(absltest.TestCase):
         )
         spec = specs.make_environment_spec(environment)
         # Construct the agent.
-        network_spec = networks.make_default_networks(spec)
+        network_spec = networks.make_default_networks(
+            spec,
+            actor_hidden_sizes=(32, 32),
+            critic_hidden_sizes=(32, 32),
+            num_layers=4,
+        )
         agent = SACAEAgent(
             environment_spec=spec,
             networks=network_spec,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py37']
+target-version = ['py37','py38']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -8,14 +8,12 @@ dm-sonnet
 trfl
 
 # JAX and the DeepMind JAX eco-system
-# -f https://storage.googleapis.com/jax-releases/jax_releases.html
 jax==0.2.11
-jaxlib==0.1.64+cuda110
+jaxlib==0.1.64
 dm-haiku>=0.0.4
-optax<=0.0.6
+optax>=0.0.8
 rlax @ git+git://github.com/deepmind/rlax.git#egg=rlax
 typing-extensions
-distrax<=0.0.1
 
 # Reverb
 dm-reverb-nightly==0.3.0.dev20210517


### PR DESCRIPTION
Closes #31

1. Remove distrax as a dependency.
2. Do not pin requirements JAX to use the CUDA verison.
3. Add instructions to README to use CPU for running tests.